### PR TITLE
make regression test more robust and update workflow definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,10 @@
 - Migrate to Vidarr
 
 ## 1.0.3 - 2021-11-04
-- Workflow input is now fastq pairs, if multiple fastq pairs are defined the workflow will align each pair to the reference genome using bwaMem and then perform a samtools merge. The next steps remain the same. 
+- Workflow input is now fastq pairs, if multiple fastq pairs are defined the workflow will align each pair to the reference genome using bwaMem and then perform a samtools merge. The next steps remain the same.
+
+## 1.0.4 - 2021-11-17
+- Increment version to bypass Jenkins build error
+
+## Unreleased - 2021-11-24
+[GP-2881](https://jira.oicr.on.ca/browse/GP-2881) make regression test more robust 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-## 1.0.2 - 2021-06-01
-- Migrate to Vidarr
-
-## 1.0.3 - 2021-11-04
-- Workflow input is now fastq pairs, if multiple fastq pairs are defined the workflow will align each pair to the reference genome using bwaMem and then perform a samtools merge. The next steps remain the same.
+## Unreleased - 2021-11-24
+[GP-2881](https://jira.oicr.on.ca/browse/GP-2881) make regression test more robust 
 
 ## 1.0.4 - 2021-11-17
 - Increment version to bypass Jenkins build error
 
-## Unreleased - 2021-11-24
-[GP-2881](https://jira.oicr.on.ca/browse/GP-2881) make regression test more robust 
+## 1.0.3 - 2021-11-04
+- Workflow input is now fastq pairs, if multiple fastq pairs are defined the workflow will align each pair to the reference genome using bwaMem and then perform a samtools merge. The next steps remain the same.
+
+## 1.0.2 - 2021-06-01
+- Migrate to Vidarr

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -6,8 +6,13 @@ set -o pipefail
 # list output files to detect new or missing files
 ls -1
 
-# count lines for .seg, .seg.txt, correctedDepth.txt and params.txt due to nondeterministic numeric fields
-find . \( -iname "*.seg" -o -iname "*.seg.txt" -o -iname "*.correctedDepth.txt" -o -iname "*params.txt" \) -exec wc -l {} \;
+# 2. check on ID.cna.seq, from which other files are derived . : cat ID.cna.seq | cut -f 1-8 | md5sum
+cat *.cna.seg | cut -f 1-8 | md5sum
+
+
+#3. check on params.txt, from which ploidy and purity values are taken : cat id.params.txt | cut -f1-5 | md5sum
+cat *.params.txt | cut -f 1-5 | md5sum
+
 
 # check size of RData binary file
 find . -iname "*.RData" -size +0 -printf '%p found and non-zero file size\n'

--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,7 +1,6 @@
 {
     "names": [
-        "ichorcna_call_ready",
-        "ichorcna_lane_level"
+        "ichorcna_full_depth"
     ],
     "wdl": "ichorCNA.wdl"
 }

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -1,6 +1,6 @@
 [
   {
-    "id": "TGL49_1",
+    "id": "TGL49_0083",
     "description": "ichorCNA workflow test",
     "arguments": {
       "ichorCNA.bamMerge.jobMemory": null,
@@ -122,7 +122,7 @@
       "ichorCNA.bam": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -130,7 +130,7 @@
       "ichorCNA.convergedParameters": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -138,7 +138,7 @@
       "ichorCNA.correctedDepth": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -146,7 +146,7 @@
       "ichorCNA.estimatedCopyNumber": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -154,7 +154,7 @@
       "ichorCNA.plots": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -162,7 +162,7 @@
       "ichorCNA.rData": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -170,7 +170,7 @@
       "ichorCNA.segments": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -178,7 +178,7 @@
       "ichorCNA.segmentsWithSubclonalStatus": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_MATS_0002_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -188,13 +188,13 @@
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/ichorCNA/output_metrics/1.0/TGL49_1.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/ichorCNA/output_metrics/1.0/TGL49_0083.metrics",
         "type": "script"
       }
     ]
   },
   {
-    "id": "TGL49_2",
+    "id": "TGL49_0111",
     "description": "ichorCNA workflow test",
     "arguments": {
       "ichorCNA.bamMerge.jobMemory": null,
@@ -343,7 +343,7 @@
       "ichorCNA.bam": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -351,7 +351,7 @@
       "ichorCNA.convergedParameters": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -359,7 +359,7 @@
       "ichorCNA.correctedDepth": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -367,7 +367,7 @@
       "ichorCNA.estimatedCopyNumber": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -375,7 +375,7 @@
       "ichorCNA.plots": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -383,7 +383,7 @@
       "ichorCNA.rData": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -391,7 +391,7 @@
       "ichorCNA.segments": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -399,7 +399,7 @@
       "ichorCNA.segmentsWithSubclonalStatus": {
         "contents": [
           {
-            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_@JENKINSID@"
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
           }
         ],
         "type": "ALL"
@@ -409,7 +409,7 @@
       {
         "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
         "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-        "output_metrics": "/.mounts/labs/gsi/testdata/ichorCNA/output_metrics/1.0/TGL49.metrics",
+        "output_metrics": "/.mounts/labs/gsi/testdata/ichorCNA/output_metrics/1.0/TGL49_0111.metrics",
         "type": "script"
       }
     ]


### PR DESCRIPTION
-Update regression tests to use md5 sums 
-Update workflow name in vidarrbuild.json:
After discussion with Larry, the lane_level and call_ready definitions did not suit ichorCNA, so we are calling it ichorcna_full_depth in anticipation of other modifications of the workflow to become available in the future.