### PR TITLE
Always output coverage report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.7 - 2022-02-18
+- Output coverage report always
+- Split index and calculate coverage tasks
+- Add output prefix to bwamem task
+
 ## 1.0.6 - 2022-01-21
 - Add trimming to alignment step.
 - Update regression test module.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ Parameter|Value|Default|Description
 `bwaMem.slicerR1_modules`|String|"slicer/0.3.0"|Required environment modules
 `bwaMem.countChunkSize_timeout`|Int|48|Hours before task timeout
 `bwaMem.countChunkSize_jobMemory`|Int|16|Memory allocated for this job
-`bwaMem.outputFileNamePrefix`|String|"output"|Prefix for output file
 `bwaMem.numChunk`|Int|1|number of chunks to split fastq file [1, no splitting]
-`bwaMem.doTrim`|Boolean|false|if true, adapters will be trimmed before alignment
 `bwaMem.trimMinLength`|Int|1|minimum length of reads to keep [1]
 `bwaMem.trimMinQuality`|Int|0|minimum quality of read ends to keep [0]
 `bwaMem.adapter1`|String|"AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC"|adapter sequence to trim from read 1 [AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC]
@@ -84,6 +82,9 @@ Parameter|Value|Default|Description
 `calculateCoverage.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
 `calculateCoverage.modules`|String|"samtools/1.14"|Environment module name and version to load (space separated) before command execution.
 `calculateCoverage.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
+`indexBam.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
+`indexBam.modules`|String|"samtools/1.9"|Environment module name and version to load (space separated) before command execution.
+`indexBam.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
 `runReadCounter.mem`|Int|8|Memory (in GB) to allocate to the job.
 `runReadCounter.modules`|String|"samtools/1.9 hmmcopy-utils/0.1.1"|Environment module name and version to load (space separated) before command execution.
 `runReadCounter.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
@@ -133,7 +134,7 @@ Output | Type | Description
 ---|---|---
 `bam`|File?|alignment file in bam format used for the analysis (merged if input is multiple fastqs or bams).
 `bamIndex`|File?|output index file for bam aligned to genome.
-`coverageReport`|File?|json file with the mean coverage for outbam.
+`coverageReport`|File|json file with the mean coverage for outbam.
 `segments`|File|Segments called by the Viterbi algorithm.  Format is compatible with IGV.
 `segmentsWithSubclonalStatus`|File|Same as `segments` but also includes subclonal status of segments (0=clonal, 1=subclonal). Format not compatible with IGV.
 `estimatedCopyNumber`|File|Estimated copy number, log ratio, and subclone status for each bin/window.
@@ -156,9 +157,11 @@ Output | Type | Description
   ```
  CALCULATE COVERAGE
  ```
- samtools index ~{inputbam} ~{resultBai}
-
  samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }' | awk '{print "{\"mean coverage\":" $1 "}"}' > ~{outputFileNamePrefix}_coverage.json
+ ```
+ INDEX BAM
+ ```
+ samtools index ~{inputbam} ~{resultBai}
  ```
  READCOUNTER
   ```

--- a/commands.txt
+++ b/commands.txt
@@ -11,9 +11,11 @@ samtools merge -c ~{resultMergedBam} ~{sep=" " bams}
  ```
 CALCULATE COVERAGE
 ```
-samtools index ~{inputbam} ~{resultBai}
-
 samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }' | awk '{print "{\"mean coverage\":" $1 "}"}' > ~{outputFileNamePrefix}_coverage.json
+```
+INDEX BAM
+```
+samtools index ~{inputbam} ~{resultBai}
 ```
 READCOUNTER
  ```

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -257,7 +257,7 @@ task indexBam {
   meta {
     output_meta: {
       outbam: "alignment file in bam format used for the analysis (merged if input is multiple fastqs or bams).",
-      bamIndex: "output index file for bam aligned to genome.",
+      bamIndex: "output index file for bam aligned to genome."
     }
   }
 }

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -39,7 +39,8 @@ workflow ichorCNA {
           fastqR1 = ig.fastqR1,
           fastqR2 = ig.fastqR2,
           readGroups = ig.readGroups,
-          doTrim = true
+          doTrim = true,
+          outputFileNamePrefix = outputFileNamePrefix
       }
     }
 

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -72,11 +72,16 @@ workflow ichorCNA {
     }
   }
 
+  call calculateCoverage {
+    input:
+      inputbam = select_first([bamMerge.outputMergedBam,bwaMemBam,inputBamMerge.outputMergedBam,singleInputBam]),
+      outputFileNamePrefix = outputFileNamePrefix
+  }
+
   if(provisionBam==true){
-    call calculateCoverage {
+    call indexBam {
       input:
-        inputbam = select_first([bamMerge.outputMergedBam,bwaMemBam,inputBamMerge.outputMergedBam,singleInputBam]),
-        outputFileNamePrefix = outputFileNamePrefix
+        inputbam = select_first([bamMerge.outputMergedBam,bwaMemBam,inputBamMerge.outputMergedBam,singleInputBam])
     }
   }
 
@@ -97,9 +102,9 @@ workflow ichorCNA {
   }
 
   output {
-    File? bam = calculateCoverage.outbam
-    File? bamIndex = calculateCoverage.bamIndex
-    File? coverageReport = calculateCoverage.coverageReport
+    File? bam = indexBam.outbam
+    File? bamIndex = indexBam.bamIndex
+    File coverageReport = calculateCoverage.coverageReport
     File segments = runIchorCNA.segments
     File segmentsWithSubclonalStatus = runIchorCNA.segmentsWithSubclonalStatus
     File estimatedCopyNumber = runIchorCNA.estimatedCopyNumber
@@ -188,16 +193,11 @@ task calculateCoverage {
     Int timeout = 12
   }
 
-  String resultBai = "~{basename(inputbam)}.bai"
-
   command <<<
-  samtools index ~{inputbam} ~{resultBai}
   samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }' | awk '{print "{\"mean coverage\":" $1 "}"}' > ~{outputFileNamePrefix}_coverage.json
   >>>
 
   output {
-  File outbam = "~{inputbam}"
-  File bamIndex = "~{resultBai}"
   File coverageReport = "~{outputFileNamePrefix}_coverage.json"
   }
 
@@ -217,9 +217,47 @@ task calculateCoverage {
 
   meta {
     output_meta: {
+      coverageReport: "json file with the mean coverage for outbam."
+    }
+  }
+}
+
+task indexBam {
+  input {
+    File inputbam
+    Int jobMemory = 8
+    String modules = "samtools/1.9"
+    Int timeout = 12
+  }
+
+  String resultBai = "~{basename(inputbam)}.bai"
+
+  command <<<
+  samtools index ~{inputbam} ~{resultBai}
+  >>>
+
+  output {
+    File outbam = "~{inputbam}"
+    File bamIndex = "~{resultBai}"
+  }
+
+  runtime {
+    memory: "~{jobMemory} GB"
+    modules: "~{modules}"
+    timeout: "~{timeout}"
+  }
+
+  parameter_meta {
+    inputbam: "Input bam."
+    jobMemory: "Memory (in GB) to allocate to the job."
+    modules: "Environment module name and version to load (space separated) before command execution."
+    timeout: "Maximum amount of time (in hours) the task can run for."
+  }
+
+  meta {
+    output_meta: {
       outbam: "alignment file in bam format used for the analysis (merged if input is multiple fastqs or bams).",
       bamIndex: "output index file for bam aligned to genome.",
-      coverageReport: "json file with the mean coverage for outbam."
     }
   }
 }

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -43,6 +43,9 @@
       "ichorCNA.calculateCoverage.jobMemory": null,
       "ichorCNA.calculateCoverage.modules": null,
       "ichorCNA.calculateCoverage.timeout": null,
+      "ichorCNA.indexBam.jobMemory": null,
+      "ichorCNA.indexBam.modules": null,
+      "ichorCNA.indexBam.timeout": null,
       "ichorCNA.inputBam": null,
       "ichorCNA.inputBamMerge.jobMemory": null,
       "ichorCNA.inputBamMerge.modules": null,
@@ -262,6 +265,9 @@
       "ichorCNA.calculateCoverage.jobMemory": null,
       "ichorCNA.calculateCoverage.modules": null,
       "ichorCNA.calculateCoverage.timeout": null,
+      "ichorCNA.indexBam.jobMemory": null,
+      "ichorCNA.indexBam.modules": null,
+      "ichorCNA.indexBam.timeout": null,
       "ichorCNA.inputBam": null,
       "ichorCNA.inputBamMerge.jobMemory": null,
       "ichorCNA.inputBamMerge.modules": null,
@@ -508,6 +514,9 @@
       "ichorCNA.calculateCoverage.jobMemory": null,
       "ichorCNA.calculateCoverage.modules": null,
       "ichorCNA.calculateCoverage.timeout": null,
+      "ichorCNA.indexBam.jobMemory": null,
+      "ichorCNA.indexBam.modules": null,
+      "ichorCNA.indexBam.timeout": null,
       "ichorCNA.inputBam": [
         {
           "contents": {


### PR DESCRIPTION
Two updates:
1. To always output coverage report, I split the indexing and calculate coverage into separate tasks. Calculating coverage task will always run, and indexing only when we set provisionBam to "true"
2. Now using outputFileNamePrefix in the bwamem task, so that the output bams always have the outputFileNamePrefix and not use the default "output.bam"