### PR TITLE
Report more metrics and add output annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 - 2022-07-22
+## 1.1.0 - 2022-07-27
 - Collect additional metrics
 - Output metrics in json file
 - Output all plots with annotations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
+## 1.1.0 - 2022-07-22
+- Collect additional metrics
+- Output metrics in json file
+- Output all plots with annotations
+
 ## 1.0.7 - 2022-02-18
 - Output coverage report always
 - Split index and calculate coverage tasks
 - Add output prefix to bwamem task
 
 ## 1.0.6 - 2022-01-21
-- Add trimming to alignment step.
-- Update regression test module.
+- Add trimming to alignment step
+- Update regression test module
 
 ## 1.0.5 - 2022-01-07
 - Workflow input can be fastq pairs or an array of bam files. There is also an option to provision out the bam file used for the analysis, which includes a json file with coverage information.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Workflow for estimating the fraction of tumor in cell-free DNA from sWGS
 * [samtools 1.14](http://www.htslib.org/)
 * [hmmcopy-utils 0.1.1](https://github.com/broadinstitute/ichorCNA)
 * [ichorcna 0.2](https://shahlab.ca/projects/hmmcopy_utils/)
+* [python 3.9](python.org)
+* [pandas 1.4.2](https://pandas.pydata.org/)
 
 
 ## Usage
@@ -73,15 +75,18 @@ Parameter|Value|Default|Description
 `bwaMem.trimMinQuality`|Int|0|minimum quality of read ends to keep [0]
 `bwaMem.adapter1`|String|"AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC"|adapter sequence to trim from read 1 [AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC]
 `bwaMem.adapter2`|String|"AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"|adapter sequence to trim from read 2 [AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT]
+`preMergeBamMetricsFastqInput.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
+`preMergeBamMetricsFastqInput.modules`|String|"samtools/1.14"|Environment module name and version to load (space separated) before command execution.
+`preMergeBamMetricsFastqInput.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
 `bamMerge.jobMemory`|Int|32|Memory allocated indexing job
 `bamMerge.modules`|String|"samtools/1.9"|Required environment modules
 `bamMerge.timeout`|Int|72|Hours before task timeout
+`preMergeBamMetrics.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
+`preMergeBamMetrics.modules`|String|"samtools/1.14"|Environment module name and version to load (space separated) before command execution.
+`preMergeBamMetrics.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
 `inputBamMerge.jobMemory`|Int|32|Memory allocated indexing job
 `inputBamMerge.modules`|String|"samtools/1.9"|Required environment modules
 `inputBamMerge.timeout`|Int|72|Hours before task timeout
-`calculateCoverage.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
-`calculateCoverage.modules`|String|"samtools/1.14"|Environment module name and version to load (space separated) before command execution.
-`calculateCoverage.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
 `indexBam.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
 `indexBam.modules`|String|"samtools/1.9"|Environment module name and version to load (space separated) before command execution.
 `indexBam.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
@@ -126,17 +131,39 @@ Parameter|Value|Default|Description
 `runIchorCNA.modules`|String|"ichorcna/0.2"|Environment module name and version to load (space separated) before command execution.
 `runIchorCNA.mem`|Int|8|Memory (in GB) to allocate to the job.
 `runIchorCNA.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
+`getMetrics.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
+`getMetrics.modules`|String|"samtools/1.14"|Environment module name and version to load (space separated) before command execution.
+`getMetrics.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
+`createJson.jobMemory`|Int|8|Memory (in GB) to allocate to the job.
+`createJson.modules`|String|"pandas/1.4.2"|Environment module name and version to load (space separated) before command execution.
+`createJson.timeout`|Int|12|Maximum amount of time (in hours) the task can run for.
 
 
 ### Outputs
 
 Output | Type | Description
 ---|---|---
-`bam`|File?|alignment file in bam format used for the analysis (merged if input is multiple fastqs or bams).
-`bamIndex`|File?|output index file for bam aligned to genome.
-`coverageReport`|File|json file with the mean coverage for outbam.
+`solution1`|Pair[File,Map[String,String]]|Plots for solution 1.
+`solution2`|Pair[File,Map[String,String]]|Plots for solution 2.
+`solution3`|Pair[File,Map[String,String]]|Plots for solution 3.
+`solution4`|Pair[File,Map[String,String]]|Plots for solution 4.
+`solution5`|Pair[File,Map[String,String]]|Plots for solution 5.
+`solution6`|Pair[File,Map[String,String]]|Plots for solution 6.
+`solution7`|Pair[File,Map[String,String]]|Plots for solution 7.
+`solution8`|Pair[File,Map[String,String]]|Plots for solution 8.
+`solution9`|Pair[File,Map[String,String]]|Plots for solution 9.
+`solution10`|Pair[File,Map[String,String]]|Plots for solution 10.
+`solution11`|Pair[File,Map[String,String]]|Plots for solution 11.
+`solution12`|Pair[File,Map[String,String]]|Plots for solution 12.
+`solution13`|Pair[File,Map[String,String]]|Plots for solution 13.
+`solution14`|Pair[File,Map[String,String]]|Plots for solution 14.
+`solution15`|Pair[File,Map[String,String]]|Plots for solution 15.
+`solution16`|Pair[File,Map[String,String]]|Plots for solution 16.
+`bam`|File?|Bam file used as input to ichorCNA (only produced when provisionBam is True)
+`bamIndex`|File?|Bam index for bam file used as input to ichorCNA (only produced when provisionBam is True)
+`jsonMetrics`|File|Report on bam coverage, read counts and ichorCNA metrics.
 `segments`|File|Segments called by the Viterbi algorithm.  Format is compatible with IGV.
-`segmentsWithSubclonalStatus`|File|Same as `segments` but also includes subclonal status of segments (0=clonal, 1=subclonal). Format not compatible with IGV.
+`segmentsWithSubclonalStatus`|File|Same as segments but also includes subclonal status of segments (0=clonal, 1=subclonal). Format not compatible with IGV.
 `estimatedCopyNumber`|File|Estimated copy number, log ratio, and subclone status for each bin/window.
 `convergedParameters`|File|Final converged parameters for optimal solution. Also contains table of converged parameters for all solutions.
 `correctedDepth`|File|Log2 ratio of each bin/window after correction for GC and mappability biases.
@@ -146,18 +173,27 @@ Output | Type | Description
 
 ## Commands
  This section lists command(s) run by ichorCNA workflow
-
+ 
  * Running ichorCNA workflow
-
- IchorCNA allows for quantification of tumor content in cfDNA. The input for this workflow is an array of fastq pairs with their read group information or an array of bam file(s). When the input is fastqs, the ichorCNA workflow first calls bwaMem for an alignment to the specified reference genome; then if multiple fastq pairs are specified the bam files are merged using samtools. When the input is bam(s) the workflow will merge if necessary or continue. The next step prepares the data for ichorCNA which is the final step in the workflow.
-
+ 
+ IchorCNA allows for quantification of tumor content in cfDNA. The input for this workflow is an array of fastq pairs with their read group information. This ichorCNA workflow first calls bwaMem for an alignment to the specified reference genome; then if multiple fastq pairs are specified the bam files are merged using samtools. The next step prepares the data for ichorCNA which is the final step in the workflow.
+ 
  MERGE BAMS
-  ```
- samtools merge -c ~{resultMergedBam} ~{sep=" " bams}
-  ```
- CALCULATE COVERAGE
  ```
- samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }' | awk '{print "{\"mean coverage\":" $1 "}"}' > ~{outputFileNamePrefix}_coverage.json
+  samtools merge \
+  -c \
+  ~{resultMergedBam} \
+  ~{sep=" " bams}
+ ```
+ COLLECT PRE-MERGE BAM METRICS
+ ```
+ echo run_lane,read_count > ~{outputFileNamePrefix}_pre_merge_bam_metrics.csv
+ for file in ~{sep=' ' bam}
+ do
+   run=$(samtools view -H "${file}" | grep '^@RG' | cut -f 2 | cut -f 2 -d ":")
+   read_count=$(samtools view -c "${file}")
+   echo $run,$read_count >> ~{outputFileNamePrefix}_pre_merge_bam_metrics.csv
+ done;
  ```
  INDEX BAM
  ```
@@ -166,14 +202,14 @@ Output | Type | Description
  READCOUNTER
   ```
  samtools index ~{bam}
-
+ 
  # calculate chromosomes to analyze (with reads) from input data
  CHROMOSOMES_WITH_READS=$(samtools view ~{bam} $(tr ',' ' ' <<< ~{chromosomesToAnalyze}) | cut -f3 | sort -V | uniq | paste -s -d, -)
-
+ 
  # write out a chromosomes with reads for ichorCNA
  # split onto new lines (for wdl read_lines), exclude chrY, remove chr prefix, wrap in single quotes for ichorCNA
  echo "${CHROMOSOMES_WITH_READS}" | tr ',' '\n' | grep -v chrY | sed "s/chr//g" | sed -e "s/\(.*\)/'\1'/" > ichorCNAchrs.txt
-
+ 
  # convert
  readCounter \
  --window ~{windowSize} \
@@ -222,10 +258,89 @@ Output | Type | Description
      ~{"--plotYLim " + plotYLim} \
      ~{"--libdir " + libdir} \
      --outDir ~{outDir}
-
+ 
      # compress directory of plots
      tar -zcvf "~{outputFileNamePrefix}_plots.tar.gz" "~{outputFileNamePrefix}"
+ 
+     #create txt file with plot full path
+     ls $PWD/~{outputFileNamePrefix}/*genomeWide_n* > "~{outputFileNamePrefix}"_plots.txt
   ```
+  COLLECT FINAL BAM AND ICHORCNA METRICS
+  ```
+  echo coverage,read_count,tumor_fraction,ploidy > ~{outputFileNamePrefix}_bam_metrics.csv
+  coverage=$(samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }')
+  read_count=$(samtools stats ~{inputbam} | head -n 8 | tail -n 1 | cut -f 3)
+  tumor_fraction=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 2)
+  ploidy=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 3)
+  echo $coverage,$read_count,$tumor_fraction,$ploidy >> ~{outputFileNamePrefix}_bam_metrics.csv
+  cat ~{params} | tail -n 17 > ~{outputFileNamePrefix}_all_sols_metrics.csv
+  ```
+ CREATE JSON WITH METRICS COLLECTED
+ ```
+ python3 <<CODE
+ import csv, json
+ import pandas as pd
+ 
+ ### create json file with all metrics
+ bam_metric = pd.read_csv("~{bamMetrics}")
+ pre_metric = pd.read_csv("~{preBamMetrics}")
+ all_sols = pd.read_csv("~{allSolsMetrics}", sep="\t")
+ all_sols["tumor_fraction"] = round(1 - all_sols["n_est"],3)
+ all_sols["solution"] = all_sols["init"]
+ pre_metric_dict = pre_metric.to_dict('index')
+ bam_metric_dict = bam_metric.to_dict('records')[0]
+ with open("~{plotsFile}") as f:
+   lines = f.readlines()
+ 
+ #reorganize lane sequencing data
+ lanes = []
+ for lane in pre_metric_dict:
+   lanes.append(pre_metric_dict[lane])
+ 
+ #find selected solution
+ selected_sol = ""
+ for index, row in all_sols.iterrows():
+   if round(row["tumor_fraction"],2) == round(bam_metric_dict["tumor_fraction"],2) and row["phi_est"] == bam_metric_dict["ploidy"]:
+     selected_sol = row["init"]
+ 
+ #selecting metrics from all solutions
+ all_sols_metrics = {}
+ for index, row in all_sols.iterrows():
+   all_sols_metrics[row["solution"]] = {"tumor_fraction":row["tumor_fraction"],
+                                        "ploidy":row["phi_est"],
+                                        "loglik":row["loglik"]}
+ 
+ metrics_dict = {"mean_coverage": bam_metric_dict["coverage"],
+                 "total_reads": bam_metric_dict["read_count"],
+                 "lanes_sequenced": len(pre_metric_dict),
+                 "reads_per_lane":lanes,
+                 "best_solution": selected_sol,
+                 "tumor_fraction": bam_metric_dict["tumor_fraction"],
+                 "ploidy": bam_metric_dict["ploidy"],
+                 "solutions": all_sols_metrics}
+ 
+ with open("~{outputFileNamePrefix}_metrics.json", "w") as outfile:
+   json.dump(metrics_dict, outfile)
+ 
+ ### create json output file for annotations
+ output_list = []
+ for line in lines:
+   pdf_dict = {}
+   line = line.strip()
+   len_pdf_sol = len(line.split("_")[-1])
+   pdf_solution = line.split("_")[-1][0:(len_pdf_sol-4)]
+   pdf_dict["left"] = line
+   pdf_dict["right"] = {}
+   pdf_dict["right"] = metrics_dict["solutions"][pdf_solution]
+   output_list.append(pdf_dict)
+ output_dict = {}
+ output_dict["pdfs"] = output_list
+ 
+ with open("~{outputFileNamePrefix}_outputs.json", "w") as outPdfJson:
+     json.dump(output_dict, outPdfJson)
+ 
+ CODE
+ ```
  ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .

--- a/commands.txt
+++ b/commands.txt
@@ -6,12 +6,21 @@ This section lists command(s) run by ichorCNA workflow
 IchorCNA allows for quantification of tumor content in cfDNA. The input for this workflow is an array of fastq pairs with their read group information. This ichorCNA workflow first calls bwaMem for an alignment to the specified reference genome; then if multiple fastq pairs are specified the bam files are merged using samtools. The next step prepares the data for ichorCNA which is the final step in the workflow.
 
 MERGE BAMS
- ```
-samtools merge -c ~{resultMergedBam} ~{sep=" " bams}
- ```
-CALCULATE COVERAGE
 ```
-samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }' | awk '{print "{\"mean coverage\":" $1 "}"}' > ~{outputFileNamePrefix}_coverage.json
+ samtools merge \
+ -c \
+ ~{resultMergedBam} \
+ ~{sep=" " bams}
+```
+COLLECT PRE-MERGE BAM METRICS
+```
+echo run_lane,read_count > ~{outputFileNamePrefix}_pre_merge_bam_metrics.csv
+for file in ~{sep=' ' bam}
+do
+  run=$(samtools view -H "${file}" | grep '^@RG' | cut -f 2 | cut -f 2 -d ":")
+  read_count=$(samtools view -c "${file}")
+  echo $run,$read_count >> ~{outputFileNamePrefix}_pre_merge_bam_metrics.csv
+done;
 ```
 INDEX BAM
 ```
@@ -79,4 +88,83 @@ RUN ICHORCNA
 
     # compress directory of plots
     tar -zcvf "~{outputFileNamePrefix}_plots.tar.gz" "~{outputFileNamePrefix}"
+
+    #create txt file with plot full path
+    ls $PWD/~{outputFileNamePrefix}/*genomeWide_n* > "~{outputFileNamePrefix}"_plots.txt
  ```
+ COLLECT FINAL BAM AND ICHORCNA METRICS
+ ```
+ echo coverage,read_count,tumor_fraction,ploidy > ~{outputFileNamePrefix}_bam_metrics.csv
+ coverage=$(samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }')
+ read_count=$(samtools stats ~{inputbam} | head -n 8 | tail -n 1 | cut -f 3)
+ tumor_fraction=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 2)
+ ploidy=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 3)
+ echo $coverage,$read_count,$tumor_fraction,$ploidy >> ~{outputFileNamePrefix}_bam_metrics.csv
+ cat ~{params} | tail -n 17 > ~{outputFileNamePrefix}_all_sols_metrics.csv
+ ```
+CREATE JSON WITH METRICS COLLECTED
+```
+python3 <<CODE
+import csv, json
+import pandas as pd
+
+### create json file with all metrics
+bam_metric = pd.read_csv("~{bamMetrics}")
+pre_metric = pd.read_csv("~{preBamMetrics}")
+all_sols = pd.read_csv("~{allSolsMetrics}", sep="\t")
+all_sols["tumor_fraction"] = round(1 - all_sols["n_est"],3)
+all_sols["solution"] = all_sols["init"]
+pre_metric_dict = pre_metric.to_dict('index')
+bam_metric_dict = bam_metric.to_dict('records')[0]
+with open("~{plotsFile}") as f:
+  lines = f.readlines()
+
+#reorganize lane sequencing data
+lanes = []
+for lane in pre_metric_dict:
+  lanes.append(pre_metric_dict[lane])
+
+#find selected solution
+selected_sol = ""
+for index, row in all_sols.iterrows():
+  if round(row["tumor_fraction"],2) == round(bam_metric_dict["tumor_fraction"],2) and row["phi_est"] == bam_metric_dict["ploidy"]:
+    selected_sol = row["init"]
+
+#selecting metrics from all solutions
+all_sols_metrics = {}
+for index, row in all_sols.iterrows():
+  all_sols_metrics[row["solution"]] = {"tumor_fraction":row["tumor_fraction"],
+                                       "ploidy":row["phi_est"],
+                                       "loglik":row["loglik"]}
+
+metrics_dict = {"mean_coverage": bam_metric_dict["coverage"],
+                "total_reads": bam_metric_dict["read_count"],
+                "lanes_sequenced": len(pre_metric_dict),
+                "reads_per_lane":lanes,
+                "best_solution": selected_sol,
+                "tumor_fraction": bam_metric_dict["tumor_fraction"],
+                "ploidy": bam_metric_dict["ploidy"],
+                "solutions": all_sols_metrics}
+
+with open("~{outputFileNamePrefix}_metrics.json", "w") as outfile:
+  json.dump(metrics_dict, outfile)
+
+### create json output file for annotations
+output_list = []
+for line in lines:
+  pdf_dict = {}
+  line = line.strip()
+  len_pdf_sol = len(line.split("_")[-1])
+  pdf_solution = line.split("_")[-1][0:(len_pdf_sol-4)]
+  pdf_dict["left"] = line
+  pdf_dict["right"] = {}
+  pdf_dict["right"] = metrics_dict["solutions"][pdf_solution]
+  output_list.append(pdf_dict)
+output_dict = {}
+output_dict["pdfs"] = output_list
+
+with open("~{outputFileNamePrefix}_outputs.json", "w") as outPdfJson:
+    json.dump(output_dict, outPdfJson)
+
+CODE
+```

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -290,7 +290,7 @@ task preMergeBamMetrics {
   for file in ~{sep=' ' bam}
   do
     run=$(samtools view -H "${file}" | grep '^@RG' | cut -f 2 | cut -f 2 -d ":")
-    read_count=$(samtools view -c "${file}")
+    read_count=$(samtools stats "${file}" | grep ^SN | grep "raw total sequences" | cut -f 3)
     echo $run,$read_count >> ~{outputFileNamePrefix}_pre_merge_bam_metrics.csv
   done;
 
@@ -643,7 +643,7 @@ task getMetrics {
 
   echo coverage,read_count,tumor_fraction,ploidy > ~{outputFileNamePrefix}_bam_metrics.csv
   coverage=$(samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }')
-  read_count=$(samtools stats ~{inputbam} | head -n 8 | tail -n 1 | cut -f 3)
+  read_count=$(samtools stats ~{inputbam} | grep ^SN | grep "raw total sequences" | cut -f 3)
   tumor_fraction=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 2)
   ploidy=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 3)
   echo $coverage,$read_count,$tumor_fraction,$ploidy >> ~{outputFileNamePrefix}_bam_metrics.csv

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -650,7 +650,7 @@ task createJson {
     bam_metric = pd.read_csv("~{bamMetrics}")
     pre_metric = pd.read_csv("~{preBamMetrics}")
     all_sols = pd.read_csv("~{allSolsMetrics}", sep="\t")
-    all_sols["tumor_fraction"] = round(abs(all_sols["n_est"] - 1),3)
+    all_sols["tumor_fraction"] = round(1 - all_sols["n_est"],3)
     all_sols["solution"] = all_sols["init"]
     pre_metric_dict = pre_metric.to_dict('index')
     bam_metric_dict = bam_metric.to_dict('records')[0]

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -679,7 +679,7 @@ task createJson {
   >>>
 
   output {
-  File metricsJson = "~{outputFileNamePrefix}.json"
+  File metricsJson = "~{outputFileNamePrefix}_metrics.json"
   Outputs out = read_json("~{outputFileNamePrefix}_outputs.json")
   }
 

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -613,6 +613,8 @@ task createJson {
     all_sols["solution"] = all_sols["init"]
     pre_metric_dict = pre_metric.to_dict('index')
     bam_metric_dict = bam_metric.to_dict('records')[0]
+    with open("~{plotsFile}") as f:
+      lines = f.readlines()
 
     #reorganize lane sequencing data
     lanes = []
@@ -643,6 +645,25 @@ task createJson {
 
     with open("~{outputFileNamePrefix}.json", "w") as outfile:
       json.dump(metrics_dict, outfile)
+
+    #create json output file for annotations
+    output_list = []
+    for line in lines:
+      pdf_dict = {}
+      line = line.strip()
+      len_pdf_sol = len(line.split("_")[-1])
+      pdf_solution = line.split("_")[-1][0:(len_pdf_sol-4)]
+      pdf_dict["name"] = line.split("/")[-1][0:-4]
+      pdf_dict["pdf"] = {}
+      pdf_dict["pdf"]["left"] = line
+      pdf_dict["pdf"]["right"] = {}
+      pdf_dict["pdf"]["right"] = metrics_dict["solutions"][pdf_solution]
+      output_list.append(pdf_dict)
+    output_dict = {}
+    output_dict["outputs"] = output_list
+
+    with open("~{outputFileNamePrefix}_outputs.json", "w") as outPdfJson:
+        json.dump(output_dict, outPdfJson)
 
     CODE
   >>>

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -9,7 +9,8 @@ struct InputGroup {
 }
 
 struct Output {
-    Pair[File,Map[String,String]] pdf
+  String name
+  Pair[File,Map[String,String]] pdf
 }
 
 struct Outputs {
@@ -662,7 +663,7 @@ task createJson {
       line = line.strip()
       len_pdf_sol = len(line.split("_")[-1])
       pdf_solution = line.split("_")[-1][0:(len_pdf_sol-4)]
-      #pdf_dict["name"] = line.split("/")[-1][0:-4]
+      pdf_dict["name"] = line.split("/")[-1][0:-4]
       pdf_dict["pdf"] = {}
       pdf_dict["pdf"]["left"] = line
       pdf_dict["pdf"]["right"] = {}
@@ -680,7 +681,6 @@ task createJson {
   output {
   File metricsJson = "~{outputFileNamePrefix}.json"
   Outputs out = read_json("~{outputFileNamePrefix}_outputs.json")
-  #Array[Pair[File,Map[String,String]]] pdfs = read_json("~{outputFileNamePrefix}_outputs.json")
   }
 
   runtime {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -531,12 +531,12 @@ task getMetrics {
   ploidy=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 3)
   echo $coverage,$read_count,$tumor_fraction,$ploidy >> ~{outputFileNamePrefix}_bam_metrics.csv
   all_sols=$(cat ~{params} | tail -n 17)
-  echo $all_sols > ~{outputFileNamePrefix}_all_sols_metrics.txt
+  echo $all_sols > ~{outputFileNamePrefix}_all_sols_metrics.csv
   >>>
 
   output {
   File coverageReport = "~{outputFileNamePrefix}_bam_metrics.csv"
-  File all_sols_metrics = "~{outputFileNamePrefix}_all_sols_metrics.txt"
+  File all_sols_metrics = "~{outputFileNamePrefix}_all_sols_metrics.csv"
   }
 
   runtime {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -200,7 +200,24 @@ workflow ichorCNA {
       convergedParameters: "Final converged parameters for optimal solution. Also contains table of converged parameters for all solutions.",
       correctedDepth: "Log2 ratio of each bin/window after correction for GC and mappability biases.",
       rData: "Saved R image after ichorCNA has finished. Results for all solutions will be included.",
-      plots: "Archived directory of plots."
+      plots: "Archived directory of plots.",
+      solution1: "Plots for solution 1.",
+      solution2: "Plots for solution 2.",
+      solution3: "Plots for solution 3.",
+      solution4: "Plots for solution 4.",
+      solution5: "Plots for solution 5.",
+      solution6: "Plots for solution 6.",
+      solution7: "Plots for solution 7.",
+      solution8: "Plots for solution 8.",
+      solution9: "Plots for solution 9.",
+      solution10: "Plots for solution 10.",
+      solution11: "Plots for solution 11.",
+      solution12: "Plots for solution 12.",
+      solution13: "Plots for solution 13.",
+      solution14: "Plots for solution 14.",
+      solution15: "Plots for solution 15.",
+      solution16: "Plots for solution 16."
+
     }
   }
 }
@@ -581,7 +598,22 @@ task runIchorCNA {
       rData: "Saved R image after ichorCNA has finished. Results for all solutions will be included.",
       plots: "Archived directory of plots.",
       plotsTxt: "Text file with the full path to the solution 1-16 pdfs.",
-      solution1: "solution 1-16, plots for each of the different solutions."
+      solution1: "Plots for solution 1.",
+      solution2: "Plots for solution 2.",
+      solution3: "Plots for solution 3.",
+      solution4: "Plots for solution 4.",
+      solution5: "Plots for solution 5.",
+      solution6: "Plots for solution 6.",
+      solution7: "Plots for solution 7.",
+      solution8: "Plots for solution 8.",
+      solution9: "Plots for solution 9.",
+      solution10: "Plots for solution 10.",
+      solution11: "Plots for solution 11.",
+      solution12: "Plots for solution 12.",
+      solution13: "Plots for solution 13.",
+      solution14: "Plots for solution 14.",
+      solution15: "Plots for solution 15.",
+      solution16: "Plots for solution 16."
     }
   }
 }

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -284,7 +284,7 @@ task preMergeBamMetrics {
   }
 
   command <<<
-  set -exo pipefail
+  set -euo pipefail
 
   echo run_lane,read_count > ~{outputFileNamePrefix}_pre_merge_bam_metrics.csv
   for file in ~{sep=' ' bam}
@@ -377,7 +377,7 @@ task runReadCounter {
   }
 
   command <<<
-    set -euxo pipefail
+    set -euo pipefail
 
     samtools index ~{bam}
 
@@ -506,6 +506,8 @@ task runIchorCNA {
   }
 
   command <<<
+    set -euo pipefail
+
     runIchorCNA \
     --WIG ~{wig} \
     ~{"--NORMWIG " + normalWig} \
@@ -637,6 +639,8 @@ task getMetrics {
   }
 
   command <<<
+  set -euo pipefail
+
   echo coverage,read_count,tumor_fraction,ploidy > ~{outputFileNamePrefix}_bam_metrics.csv
   coverage=$(samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }')
   read_count=$(samtools stats ~{inputbam} | head -n 8 | tail -n 1 | cut -f 3)
@@ -688,6 +692,8 @@ task createJson {
   }
 
   command <<<
+    set -euo pipefail
+
     python3 <<CODE
     import csv, json
     import pandas as pd

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -530,8 +530,7 @@ task getMetrics {
   tumor_fraction=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 2)
   ploidy=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 3)
   echo $coverage,$read_count,$tumor_fraction,$ploidy >> ~{outputFileNamePrefix}_bam_metrics.csv
-  all_sols=$(cat ~{params} | tail -n 17)
-  echo $all_sols > ~{outputFileNamePrefix}_all_sols_metrics.csv
+  cat ~{params} | tail -n 17 > ~{outputFileNamePrefix}_all_sols_metrics.csv
   >>>
 
   output {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -110,7 +110,7 @@ workflow ichorCNA {
       wig=runReadCounter.wig
   }
 
-  call calculateCoverage {
+  call getMetrics {
     input:
       inputbam = select_first([bamMerge.outputMergedBam,bwaMemBam,inputBamMerge.outputMergedBam,singleInputBam]),
       params = runIchorCNA.convergedParameters,
@@ -120,7 +120,7 @@ workflow ichorCNA {
   output {
     File? bam = indexBam.outbam
     File? bamIndex = indexBam.bamIndex
-    File coverageReport = calculateCoverage.coverageReport
+    File jsonMetrics = getMetrics.coverageReport
     File segments = runIchorCNA.segments
     File segmentsWithSubclonalStatus = runIchorCNA.segmentsWithSubclonalStatus
     File estimatedCopyNumber = runIchorCNA.estimatedCopyNumber
@@ -513,7 +513,7 @@ task runIchorCNA {
   }
 }
 
-task calculateCoverage {
+task getMetrics {
   input {
     File inputbam
     File params
@@ -530,10 +530,13 @@ task calculateCoverage {
   tumor_fraction=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 2)
   ploidy=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 3)
   echo $coverage,$read_count,$tumor_fraction,$ploidy >> ~{outputFileNamePrefix}_bam_metrics.csv
+  all_sols=$(cat ~{params} | tail -n 17)
+  echo $all_sols > ~{outputFileNamePrefix}_all_sols_metrics.txt
   >>>
 
   output {
   File coverageReport = "~{outputFileNamePrefix}_bam_metrics.csv"
+  File all_sols_metrics = "~{outputFileNamePrefix}_all_sols_metrics.txt"
   }
 
   runtime {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -8,6 +8,15 @@ struct InputGroup {
   String readGroups
 }
 
+struct Output {
+    String name
+    Pair[File,Map[String,String]] pdf
+}
+
+struct Outputs {
+    Array[Output]+ outputs
+}
+
 workflow ichorCNA {
   input {
     Array[InputGroup]? inputGroups
@@ -127,6 +136,7 @@ workflow ichorCNA {
   }
 
   output {
+    Array[Output]+ pdf = createJson.out.outputs
     File? bam = indexBam.outbam
     File? bamIndex = indexBam.bamIndex
     File jsonMetrics = createJson.metricsJson
@@ -670,6 +680,7 @@ task createJson {
 
   output {
   File metricsJson = "~{outputFileNamePrefix}.json"
+  Outputs out = read_json("~{outputFileNamePrefix}_outputs.json")
   }
 
   runtime {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -571,7 +571,7 @@ task runIchorCNA {
       rData: "Saved R image after ichorCNA has finished. Results for all solutions will be included.",
       plots: "Archived directory of plots.",
       plotsTxt: "Text file with the full path to the solution 1-16 pdfs.",
-      solution1-16: "Plots for each of the different solutions."
+      solution1: "solution 1-16, plots for each of the different solutions."
     }
   }
 }

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -122,6 +122,7 @@ workflow ichorCNA {
       bamMetrics = getMetrics.bamMetrics,
       preBamMetrics = select_first([preMergeBamMetrics.preMergeMetrics,preMergeBamMetricsFastqInput.preMergeMetrics]),
       allSolsMetrics = getMetrics.all_sols_metrics,
+      plotsFile = runIchorCNA.plotsTxt,
       outputFileNamePrefix = outputFileNamePrefix
   }
 
@@ -446,6 +447,9 @@ task runIchorCNA {
 
     # compress directory of plots
     tar -zcvf "~{outputFileNamePrefix}_plots.tar.gz" "~{outputFileNamePrefix}"
+
+    #create txt file with plot full path
+    ls $PWD/~{outputFileNamePrefix}/*genomeWide_n* > "~{outputFileNamePrefix}"_plots.txt
   >>>
 
   runtime {
@@ -462,6 +466,24 @@ task runIchorCNA {
     File correctedDepth = "~{outputFileNamePrefix}.correctedDepth.txt"
     File rData = "~{outputFileNamePrefix}.RData"
     File plots = "~{outputFileNamePrefix}_plots.tar.gz"
+    File plotsTxt = "~{outputFileNamePrefix}_plots.txt"
+    File solution1 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.2-p2.pdf"
+    File solution2 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.2-p3.pdf"
+    File solution3 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.3-p2.pdf"
+    File solution4 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.3-p3.pdf"
+    File solution5 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.4-p2.pdf"
+    File solution6 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.4-p3.pdf"
+    File solution7 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.5-p2.pdf"
+    File solution8 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.5-p3.pdf"
+    File solution9 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.6-p2.pdf"
+    File solution10 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.6-p3.pdf"
+    File solution11 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.7-p2.pdf"
+    File solution12 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.7-p3.pdf"
+    File solution13 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.8-p2.pdf"
+    File solution14 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.8-p3.pdf"
+    File solution15 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.9-p2.pdf"
+    File solution16 = "~{outputFileNamePrefix}/~{outputFileNamePrefix}_genomeWide_n0.9-p3.pdf"
+
   }
 
   parameter_meta {
@@ -572,6 +594,7 @@ task createJson {
     File preBamMetrics
     File bamMetrics
     File allSolsMetrics
+    File plotsFile
     String outputFileNamePrefix
     Int jobMemory = 8
     String modules = "pandas/1.4.2"

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -592,7 +592,7 @@ task getMetrics {
   command <<<
   echo coverage,read_count,tumor_fraction,ploidy > ~{outputFileNamePrefix}_bam_metrics.csv
   coverage=$(samtools coverage ~{inputbam} | grep -P "^chr\d+\t|^chrX\t|^chrY\t" | awk '{ space += ($3-$2)+1; bases += $7*($3-$2);} END { print bases/space }')
-  read_count=$(samtools view -c ~{inputbam})
+  read_count=$(samtools stats ~{inputbam} | head -n 8 | tail -n 1 | cut -f 3)
   tumor_fraction=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 2)
   ploidy=$(cat ~{params} | head -n 2 | tail -n 1 | cut -f 3)
   echo $coverage,$read_count,$tumor_fraction,$ploidy >> ~{outputFileNamePrefix}_bam_metrics.csv

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -145,8 +145,8 @@ workflow ichorCNA {
   }
 
   meta {
-    author: "Michael Laszloffy"
-    email: "michael.laszloffy@oicr.on.ca"
+    author: "Beatriz Lujan Toro"
+    email: "beatriz.lujantoro@oicr.on.ca"
     description: "Workflow for estimating the fraction of tumor in cell-free DNA from sWGS"
     dependencies: [
       {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -9,7 +9,6 @@ struct InputGroup {
 }
 
 struct Output {
-    String name
     Pair[File,Map[String,String]] pdf
 }
 
@@ -663,7 +662,7 @@ task createJson {
       line = line.strip()
       len_pdf_sol = len(line.split("_")[-1])
       pdf_solution = line.split("_")[-1][0:(len_pdf_sol-4)]
-      pdf_dict["name"] = line.split("/")[-1][0:-4]
+      #pdf_dict["name"] = line.split("/")[-1][0:-4]
       pdf_dict["pdf"] = {}
       pdf_dict["pdf"]["left"] = line
       pdf_dict["pdf"]["right"] = {}
@@ -681,6 +680,7 @@ task createJson {
   output {
   File metricsJson = "~{outputFileNamePrefix}.json"
   Outputs out = read_json("~{outputFileNamePrefix}_outputs.json")
+  #Array[Pair[File,Map[String,String]]] pdfs = read_json("~{outputFileNamePrefix}_outputs.json")
   }
 
   runtime {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -8,13 +8,8 @@ struct InputGroup {
   String readGroups
 }
 
-struct Output {
-  String name
-  Pair[File,Map[String,String]] pdf
-}
-
-struct Outputs {
-    Array[Output]+ outputs
+struct PdfOutput {
+  Array[Pair[File,Map[String,String]]]+ pdfs
 }
 
 workflow ichorCNA {
@@ -136,7 +131,7 @@ workflow ichorCNA {
   }
 
   output {
-    Array[Output]+ pdf = createJson.out.outputs
+    Array[Pair[File,Map[String,String]]]+ pdfs = createJson.pdfOutput.pdfs
     File? bam = indexBam.outbam
     File? bamIndex = indexBam.bamIndex
     File jsonMetrics = createJson.metricsJson
@@ -699,14 +694,12 @@ task createJson {
       line = line.strip()
       len_pdf_sol = len(line.split("_")[-1])
       pdf_solution = line.split("_")[-1][0:(len_pdf_sol-4)]
-      pdf_dict["name"] = line.split("/")[-1][0:-4]
-      pdf_dict["pdf"] = {}
-      pdf_dict["pdf"]["left"] = line
-      pdf_dict["pdf"]["right"] = {}
-      pdf_dict["pdf"]["right"] = metrics_dict["solutions"][pdf_solution]
+      pdf_dict["left"] = line
+      pdf_dict["right"] = {}
+      pdf_dict["right"] = metrics_dict["solutions"][pdf_solution]
       output_list.append(pdf_dict)
     output_dict = {}
-    output_dict["outputs"] = output_list
+    output_dict["pdfs"] = output_list
 
     with open("~{outputFileNamePrefix}_outputs.json", "w") as outPdfJson:
         json.dump(output_dict, outPdfJson)
@@ -715,8 +708,8 @@ task createJson {
   >>>
 
   output {
-  File metricsJson = "~{outputFileNamePrefix}_metrics.json"
-  Outputs out = read_json("~{outputFileNamePrefix}_outputs.json")
+    File metricsJson = "~{outputFileNamePrefix}_metrics.json"
+    PdfOutput pdfOutput = read_json("~{outputFileNamePrefix}_outputs.json")
   }
 
   runtime {

--- a/ichorCNA.wdl
+++ b/ichorCNA.wdl
@@ -131,7 +131,22 @@ workflow ichorCNA {
   }
 
   output {
-    Array[Pair[File,Map[String,String]]]+ pdfs = createJson.pdfOutput.pdfs
+    Pair[File,Map[String,String]] solution1 = createJson.pdfOutput.pdfs[0]
+    Pair[File,Map[String,String]] solution2 = createJson.pdfOutput.pdfs[1]
+    Pair[File,Map[String,String]] solution3 = createJson.pdfOutput.pdfs[2]
+    Pair[File,Map[String,String]] solution4 = createJson.pdfOutput.pdfs[3]
+    Pair[File,Map[String,String]] solution5 = createJson.pdfOutput.pdfs[4]
+    Pair[File,Map[String,String]] solution6 = createJson.pdfOutput.pdfs[5]
+    Pair[File,Map[String,String]] solution7 = createJson.pdfOutput.pdfs[6]
+    Pair[File,Map[String,String]] solution8 = createJson.pdfOutput.pdfs[7]
+    Pair[File,Map[String,String]] solution9 = createJson.pdfOutput.pdfs[8]
+    Pair[File,Map[String,String]] solution10 = createJson.pdfOutput.pdfs[9]
+    Pair[File,Map[String,String]] solution11 = createJson.pdfOutput.pdfs[10]
+    Pair[File,Map[String,String]] solution12 = createJson.pdfOutput.pdfs[11]
+    Pair[File,Map[String,String]] solution13 = createJson.pdfOutput.pdfs[12]
+    Pair[File,Map[String,String]] solution14 = createJson.pdfOutput.pdfs[13]
+    Pair[File,Map[String,String]] solution15 = createJson.pdfOutput.pdfs[14]
+    Pair[File,Map[String,String]] solution16 = createJson.pdfOutput.pdfs[15]
     File? bam = indexBam.outbam
     File? bamIndex = indexBam.bamIndex
     File jsonMetrics = createJson.metricsJson

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -3,19 +3,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# list output files to detect new or missing files
+#1. list output files to detect new or missing files
 ls -1
 
-# 2. check on ID.cna.seq, from which other files are derived . : cat ID.cna.seq | cut -f 1-8 | md5sum
+#2. check on ID.cna.seq, from which other files are derived . : cat ID.cna.seq | cut -f 1-8 | md5sum
 cat *.cna.seg | cut -f 1-8 | md5sum
 
 
 #3. check on params.txt, from which ploidy and purity values are taken : cat id.params.txt | cut -f1-5 | md5sum
 cat *.params.txt | cut -f 1-5 | md5sum
 
+#4. check metrics json
+cat *_metrics.json | md5sum
 
-# check size of RData binary file
+#5. check size of RData binary file
 find . -iname "*.RData" -size +0 -printf '%p found and non-zero file size\n'
 
-# calculate what report files are archived
+#6. calculate what report files are archived
 tar --list --file *_plots.tar.gz

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -13,8 +13,8 @@ cat *.cna.seg | cut -f 1-8 | md5sum
 #3. check on params.txt, from which ploidy and purity values are taken : cat id.params.txt | cut -f1-5 | md5sum
 cat *.params.txt | cut -f 1-5 | md5sum
 
-#4. check metrics json
-cat *_metrics.json | md5sum
+#4. check metrics json, ignore loglik
+cat *_metrics.json | tr , '\n' | grep -v loglik | md5sum
 
 #5. check size of RData binary file
 find . -iname "*.RData" -size +0 -printf '%p found and non-zero file size\n'

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -237,6 +237,134 @@
           }
         ],
         "type": "ALL"
+      },
+      "ichorCNA.solution1": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution2": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution3": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution4": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution5": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution6": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution7": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution8": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution9": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution10": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution11": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution12": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution13": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution14": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution15": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution16": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
       }
     },
     "validators": [
@@ -513,6 +641,134 @@
           }
         ],
         "type": "ALL"
+      },
+      "ichorCNA.solution1": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution2": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution3": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution4": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution5": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution6": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution7": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution8": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution9": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution10": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution11": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution12": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution13": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution14": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution15": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution16": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
       }
     },
     "validators": [
@@ -741,6 +997,134 @@
         "type": "ALL"
       },
       "ichorCNA.segmentsWithSubclonalStatus": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution1": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution2": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution3": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution4": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution5": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution6": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution7": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution8": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution9": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution10": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution11": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution12": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution13": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution14": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution15": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.solution16": {
         "contents": [
           {
             "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -40,9 +40,12 @@
       "ichorCNA.bwaMem.trimMinLength": null,
       "ichorCNA.bwaMem.trimMinQuality": null,
       "ichorCNA.chromosomesToAnalyze": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY",
-      "ichorCNA.calculateCoverage.jobMemory": null,
-      "ichorCNA.calculateCoverage.modules": null,
-      "ichorCNA.calculateCoverage.timeout": null,
+      "ichorCNA.createJson.jobMemory": null,
+      "ichorCNA.createJson.modules": null,
+      "ichorCNA.createJson.timeout": null,
+      "ichorCNA.getMetrics.jobMemory": null,
+      "ichorCNA.getMetrics.modules": null,
+      "ichorCNA.getMetrics.timeout": null,
       "ichorCNA.indexBam.jobMemory": null,
       "ichorCNA.indexBam.modules": null,
       "ichorCNA.indexBam.timeout": null,
@@ -82,6 +85,14 @@
       "ichorCNA.inputType":"fastq",
       "ichorCNA.minimumMappingQuality": 20,
       "ichorCNA.outputFileNamePrefix": "TGL49_0083_Ov_P_PE_321_WG",
+      "ichorCNA.preMergeBamMetrics.bam": null,
+      "ichorCNA.preMergeBamMetrics.outputFileNamePrefix": null,
+      "ichorCNA.preMergeBamMetrics.jobMemory": null,
+      "ichorCNA.preMergeBamMetrics.modules": null,
+      "ichorCNA.preMergeBamMetrics.timeout": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.jobMemory": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.modules": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.timeout": null,
       "ichorCNA.provisionBam": false,
       "ichorCNA.runIchorCNA.altFracThreshold": null,
       "ichorCNA.runIchorCNA.centromere": "$ICHORCNA_ROOT/lib/R/ichorCNA/extdata/GRCh38.GCA_000001405.2_centromere_acen.txt",
@@ -179,6 +190,22 @@
         ],
         "type": "ALL"
       },
+      "ichorCNA.jsonMetrics": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.pdfs": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0083_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
       "ichorCNA.plots": {
         "contents": [
           {
@@ -262,9 +289,12 @@
       "ichorCNA.bwaMem.trimMinLength": null,
       "ichorCNA.bwaMem.trimMinQuality": null,
       "ichorCNA.chromosomesToAnalyze": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY",
-      "ichorCNA.calculateCoverage.jobMemory": null,
-      "ichorCNA.calculateCoverage.modules": null,
-      "ichorCNA.calculateCoverage.timeout": null,
+      "ichorCNA.createJson.jobMemory": null,
+      "ichorCNA.createJson.modules": null,
+      "ichorCNA.createJson.timeout": null,
+      "ichorCNA.getMetrics.jobMemory": null,
+      "ichorCNA.getMetrics.modules": null,
+      "ichorCNA.getMetrics.timeout": null,
       "ichorCNA.indexBam.jobMemory": null,
       "ichorCNA.indexBam.modules": null,
       "ichorCNA.indexBam.timeout": null,
@@ -331,6 +361,14 @@
       "ichorCNA.inputType":"fastq",
       "ichorCNA.minimumMappingQuality": 20,
       "ichorCNA.outputFileNamePrefix": "TGL49_0111_Cf_U_PE_330_WG",
+      "ichorCNA.preMergeBamMetrics.bam": null,
+      "ichorCNA.preMergeBamMetrics.outputFileNamePrefix": null,
+      "ichorCNA.preMergeBamMetrics.jobMemory": null,
+      "ichorCNA.preMergeBamMetrics.modules": null,
+      "ichorCNA.preMergeBamMetrics.timeout": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.jobMemory": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.modules": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.timeout": null,
       "ichorCNA.provisionBam": true,
       "ichorCNA.runIchorCNA.altFracThreshold": null,
       "ichorCNA.runIchorCNA.centromere": "$ICHORCNA_ROOT/lib/R/ichorCNA/extdata/GRCh38.GCA_000001405.2_centromere_acen.txt",
@@ -428,6 +466,22 @@
         ],
         "type": "ALL"
       },
+      "ichorCNA.jsonMetrics": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.pdfs": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL49_0111_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
       "ichorCNA.plots": {
         "contents": [
           {
@@ -511,9 +565,12 @@
       "ichorCNA.bwaMem.trimMinLength": null,
       "ichorCNA.bwaMem.trimMinQuality": null,
       "ichorCNA.chromosomesToAnalyze": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY",
-      "ichorCNA.calculateCoverage.jobMemory": null,
-      "ichorCNA.calculateCoverage.modules": null,
-      "ichorCNA.calculateCoverage.timeout": null,
+      "ichorCNA.createJson.jobMemory": null,
+      "ichorCNA.createJson.modules": null,
+      "ichorCNA.createJson.timeout": null,
+      "ichorCNA.getMetrics.jobMemory": null,
+      "ichorCNA.getMetrics.modules": null,
+      "ichorCNA.getMetrics.timeout": null,
       "ichorCNA.indexBam.jobMemory": null,
       "ichorCNA.indexBam.modules": null,
       "ichorCNA.indexBam.timeout": null,
@@ -538,6 +595,14 @@
       "ichorCNA.inputType":"bam",
       "ichorCNA.minimumMappingQuality": 20,
       "ichorCNA.outputFileNamePrefix": "TGL48_0001_Ct_T_PE_312_WG",
+      "ichorCNA.preMergeBamMetrics.jobMemory": null,
+      "ichorCNA.preMergeBamMetrics.modules": null,
+      "ichorCNA.preMergeBamMetrics.timeout": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.bam": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.outputFileNamePrefix": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.jobMemory": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.modules": null,
+      "ichorCNA.preMergeBamMetricsFastqInput.timeout": null,
       "ichorCNA.provisionBam": false,
       "ichorCNA.runIchorCNA.altFracThreshold": null,
       "ichorCNA.runIchorCNA.centromere": "$ICHORCNA_ROOT/lib/R/ichorCNA/extdata/GRCh38.GCA_000001405.2_centromere_acen.txt",
@@ -628,6 +693,22 @@
         "type": "ALL"
       },
       "ichorCNA.estimatedCopyNumber": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.jsonMetrics": {
+        "contents": [
+          {
+            "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"
+          }
+        ],
+        "type": "ALL"
+      },
+      "ichorCNA.pdfs": {
         "contents": [
           {
             "outputDirectory": "@SCRATCH@/@DATE@_Workflow_ichorCNA_TGL48_0001_@JENKINSID@"


### PR DESCRIPTION
We want to report more metrics after ichorCNA is run, previously only coverage was reported. https://jira.oicr.on.ca/browse/GRD-422 , we now want to report: 

-   mean coverage
-   total reads 
-   lanes sequenced
-   reads per lane

In addition, there is a request to sort the output pdfs to folders for easier review of the data: https://jira.oicr.on.ca/browse/GBS-3418

For this we are adding annotations to the pdf output files. 
